### PR TITLE
[exporter] support config and export of histogram metrics.

### DIFF
--- a/config.yml.dist
+++ b/config.yml.dist
@@ -125,3 +125,41 @@ jobs:
       WHERE partition IN
           (SELECT max(partition)
           FROM my_athena_db.some_table);
+- name: "clickhouse"
+  interval: '5m'
+  connections:
+  - 'clickhouse://USERNAME:PASSWORD@localhost:9090/default'
+  queries:
+  - name: "http_requests_hist"
+    help: "HTTP requests histogram buckets"
+    type: "histogram"
+    labels:
+      - "status_code"
+    hist_values:
+      - name: "http_request_duration_hist"
+        count: "http_request_duration_hist_count"
+        sum: "http_request_duration_hist_sum"
+        buckets:
+          - name: "http_request_duration_hist_bucket_b100"
+            value: "0.1"
+          - name: "http_request_duration_hist_bucket_b500"
+            value: "0.5"
+          - name: "http_request_duration_hist_bucket_b1000"
+            value: "1.0"
+          - name: "http_request_duration_hist_bucket_b2500"
+            value: "2.5"
+          - name: "http_request_duration_hist_bucket_b5000"
+            value: "5.0"
+    query:  |
+            SELECT
+              toString(http_code) AS status_code,
+              sum(http_request_duration_100ms) AS http_request_duration_hist_bucket_b100,
+              sum(http_request_duration_500ms) AS http_request_duration_hist_bucket_b500,
+              sum(http_request_duration_1000ms) AS http_request_duration_hist_bucket_b1000,
+              sum(http_request_duration_2500ms) AS http_request_duration_hist_bucket_b2500,
+              sum(http_request_duration_5000ms) AS http_request_duration_hist_bucket_b5000,
+              sum(http_request_duration_ms) AS http_request_duration_hist_sum,
+              count(*) AS http_request_duration_hist_count
+            FROM http_requests
+            GROUP BY
+              status_code;

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+const (
+	testPostgresGuageConfigYAML = `
+jobs:
+- name: "global"
+  interval: '5m'
+  connections:
+  - 'postgres://postgres@localhost/postgres?sslmode=disable'
+  startup_sql:
+  - 'SET lock_timeout = 1000'
+  - 'SET idle_in_transaction_session_timeout = 100'
+  queries:
+  - name: "running_queries"
+    help: "Number of running queries"
+    type: "gauge"
+    labels:
+      - "datname"
+      - "usename"
+    values:
+      - "count"
+    query:  |
+            SELECT datname::text, usename::text, COUNT(*)::float AS count
+            FROM pg_stat_activity GROUP BY datname, usename;
+`
+
+	testClickhouseHistogramConfigYAML = `
+jobs:
+- name: "global"
+  interval: '5m'
+  connections:
+  - 'clickhouse://USERNAME:PASSWORD@localhost:9090/default'
+  queries:
+  - name: "http_requests_hist"
+    help: "HTTP requests histogram buckets"
+    type: "histogram"
+    labels:
+      - "status_code"
+    hist_values:
+      - name: "http_request_duration_hist"
+        count: "http_request_duration_hist_count"
+        sum: "http_request_duration_hist_sum"
+        buckets:
+          - name: "http_request_duration_hist_bucket_b100"
+            value: "0.1"
+          - name: "http_request_duration_hist_bucket_b500"
+            value: "0.5"
+          - name: "http_request_duration_hist_bucket_b1000"
+            value: "1.0"
+          - name: "http_request_duration_hist_bucket_b2500"
+            value: "2.5"
+          - name: "http_request_duration_hist_bucket_b5000"
+            value: "5.0"
+    query:  |
+            SELECT
+              toString(http_code) AS status_code,
+              sum(http_request_duration_100ms) AS http_request_duration_hist_bucket_b100,
+              sum(http_request_duration_500ms) AS http_request_duration_hist_bucket_b500,
+              sum(http_request_duration_1000ms) AS http_request_duration_hist_bucket_b1000,
+              sum(http_request_duration_2500ms) AS http_request_duration_hist_bucket_b2500,
+              sum(http_request_duration_5000ms) AS http_request_duration_hist_bucket_b5000,
+              sum(http_request_duration_ms) AS http_request_duration_hist_sum,
+              count(*) AS http_request_duration_hist_count
+            FROM http_requests
+            GROUP BY
+              status_code;
+`
+)
+
+func Test_parseConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		in   io.Reader
+		out  File
+	}{
+		{
+			name: "postgres guage",
+			in:   strings.NewReader(testPostgresGuageConfigYAML),
+			out: File{
+				Jobs: []*Job{
+					&Job{
+						Name:        "global",
+						Interval:    5 * time.Minute,
+						Connections: []string{"postgres://postgres@localhost/postgres?sslmode=disable"},
+						StartupSQL: []string{
+							"SET lock_timeout = 1000",
+							"SET idle_in_transaction_session_timeout = 100",
+						},
+						Queries: []*Query{
+							&Query{
+								Name:   "running_queries",
+								Help:   "Number of running queries",
+								Type:   "gauge",
+								Labels: []string{"datname", "usename"},
+								Values: []string{"count"},
+								Query:  "SELECT datname::text, usename::text, COUNT(*)::float AS count\nFROM pg_stat_activity GROUP BY datname, usename;\n",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "clickhouse histogram",
+			in:   strings.NewReader(testClickhouseHistogramConfigYAML),
+			out: File{
+				Jobs: []*Job{
+					&Job{
+						Name:        "global",
+						Interval:    5 * time.Minute,
+						Connections: []string{"clickhouse://USERNAME:PASSWORD@localhost:9090/default"},
+						Queries: []*Query{
+							&Query{
+								Name: "http_requests_hist",
+								Help: "HTTP requests histogram buckets",
+								Type: "histogram",
+								Labels: []string{
+									"status_code",
+								},
+								HistValues: []*HistValue{
+									&HistValue{
+										Count: "http_request_duration_hist_count",
+										Sum:   "http_request_duration_hist_sum",
+										Buckets: []*Bucket{
+											&Bucket{Name: "http_request_duration_hist_bucket_b100", Value: "0.1"},
+											&Bucket{Name: "http_request_duration_hist_bucket_b500", Value: "0.5"},
+											&Bucket{Name: "http_request_duration_hist_bucket_b1000", Value: "1.0"},
+											&Bucket{Name: "http_request_duration_hist_bucket_b2500", Value: "2.5"},
+											&Bucket{Name: "http_request_duration_hist_bucket_b5000", Value: "5.0"},
+										},
+									},
+								},
+								Query: "SELECT\n  toString(http_code) AS status_code,\n  sum(http_request_duration_100ms) AS http_request_duration_hist_bucket_b100,\n  sum(http_request_duration_500ms) AS http_request_duration_hist_bucket_b500,\n  sum(http_request_duration_1000ms) AS http_request_duration_hist_bucket_b1000,\n  sum(http_request_duration_2500ms) AS http_request_duration_hist_bucket_b2500,\n  sum(http_request_duration_5000ms) AS http_request_duration_hist_bucket_b5000,\n  sum(http_request_duration_ms) AS http_request_duration_hist_sum,\n  count(*) AS http_request_duration_hist_count\nFROM http_requests\nGROUP BY\n  status_code;\n",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseConfig(tt.in)
+			if err != nil {
+				t.Errorf("got unexpected error: %v", err)
+			} else if diff := pretty.Compare(tt.out, got); diff != "" {
+				t.Errorf("expected response was not as expected (-have +want):\n\n%s", diff)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,9 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/jmoiron/sqlx v1.2.0
+	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
 	github.com/lib/pq v1.3.0
+	github.com/mailru/go-clickhouse v1.3.0
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,14 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
+github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/mailru/go-clickhouse v1.3.0 h1:KPtNyrSpOlx5Cfq2xoA2GN95kRA7V7xjXqXgR3XMq9o=
+github.com/mailru/go-clickhouse v1.3.0/go.mod h1:MRUTPjUvZIjSa0dop27y1HVKBTQ7kt27BD9TpIrgWjw=
 github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -89,6 +93,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/satori/go.uuid v1.1.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/go-athena v0.0.0-20181208004937-dfa5f1818930 h1:Tn2Ryh7e9oN9TK19Y0vP/1Rfr1/DqBxXC8qrWKS4ez8=


### PR DESCRIPTION
Adds support for exporting prometheus histogram metrics. Query config can be defined to map histograms:
```
jobs:
- name: "clickhouse"
  interval: '5m'
  connections:
  - 'clickhouse://USERNAME:PASSWORD@localhost:9090/default'
  queries:
  - name: "http_requests_hist"
    help: "HTTP requests histogram buckets"
    type: "histogram"
    labels:
      - "status_code"
    hist_values:
      - name: "http_request_duration_hist"
        count: "http_request_duration_hist_count"
        sum: "http_request_duration_hist_sum"
        buckets:
          - name: "http_request_duration_hist_bucket_b100"
            value: "0.1"
          - name: "http_request_duration_hist_bucket_b500"
            value: "0.5"
          - name: "http_request_duration_hist_bucket_b1000"
            value: "1.0"
          - name: "http_request_duration_hist_bucket_b2500"
            value: "2.5"
          - name: "http_request_duration_hist_bucket_b5000"
            value: "5.0"
    query:  |
            SELECT
              toString(http_code) AS status_code,
              sum(http_request_duration_100ms) AS http_request_duration_hist_bucket_b100,
              sum(http_request_duration_500ms) AS http_request_duration_hist_bucket_b500,
              sum(http_request_duration_1000ms) AS http_request_duration_hist_bucket_b1000,
              sum(http_request_duration_2500ms) AS http_request_duration_hist_bucket_b2500,
              sum(http_request_duration_5000ms) AS http_request_duration_hist_bucket_b5000,
              sum(http_request_duration_ms) AS http_request_duration_hist_sum,
              count(*) AS http_request_duration_hist_count
            FROM http_requests
            GROUP BY
              status_code;
```